### PR TITLE
Bugfix: dep keys weren't invalidating CP upon change

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -12,7 +12,7 @@ function handleDescriptor(target, key, descriptor) {
     throw new Error('ember-computed-decorators does not support using getters and setters');
   }
 
-  descriptor.value = computed(originalParams, computedDescriptor);
+  descriptor.value = computed.apply(null, originalParams.concat(computedDescriptor));
 
   return descriptor;
 }

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -27,6 +27,24 @@ test('passes dependent keys into function as arguments', function(assert) {
   get(obj, 'name');
 });
 
+test('dependent key changes invalidate the computed property', function(assert) {
+  var obj = {
+    first: 'rob',
+    last: 'jackson',
+
+    /* jshint ignore:start */
+    @computed('first', 'last')
+    /* jshint ignore:end */
+    name(first, last) {
+      return `${first} ${last}`;
+    }
+  };
+
+  assert.equal(get(obj, 'name'), 'rob jackson');
+  set(obj, 'first', 'al');
+  assert.equal(get(obj, 'name'), 'al jackson');
+});
+
 test('only calls getter when dependent keys change', function(assert) {
   let callCount = 0;
   let obj = {


### PR DESCRIPTION
Root cause: @computed('first', 'last') was actually
transpiling to a call to 
Ember.computed(['first', 'last'], fn)