### PR TITLE
a-bide by arity. If you don’t ask for it, you won’t get it.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -18,8 +18,10 @@ function handleDescriptor(target, key, descriptor) {
 }
 
 function callUserSuppliedFunction(params, func) {
+  let arityAlignedParams = params.slice(0, func.length);
+
   return function() {
-    let paramValues = params.map(p => get(this, p));
+    let paramValues = arityAlignedParams.map(p => get(this, p));
 
     return func.apply(this, paramValues);
   };

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -27,6 +27,22 @@ test('passes dependent keys into function as arguments', function(assert) {
   get(obj, 'name');
 });
 
+test('preserve arity', function(assert) {
+  var obj = {
+    first: 'rob',
+    last: 'jackson',
+
+    /* jshint ignore:start */
+    @computed('first', 'last', 'middle')
+    /* jshint ignore:end */
+    name(first, last) {
+      assert.equal(arguments.length, 2);
+    }
+  };
+
+  get(obj, 'name');
+});
+
 test('dependent key changes invalidate the computed property', function(assert) {
   var obj = {
     first: 'rob',


### PR DESCRIPTION
this is more controversial then the last PR, but would love to get some thoughts/eyes on it.

It is possible for a CP to cause an invalidation, but to never be recomputed if it is never `get`'d. By always  getting CPs even if no arg for them is used, we do somewhat change the semantics.

Unfortunately, and likely why this should be merged is restArgs and arguments hacks wont work.

```js

var a = {
  @computed('firstName', 'lastName')
  foo(...names) {
    return names.filter(Boolean).join(' ');
  }
};
```