### PR TITLE
make get/set structure work

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ export default Ember.Component.extend({
 });
 ```
 
+
+#### "Real World get/set syntax"
+
+```javascript
+import Ember from 'ember';
+import computed from 'ember-computed-decorators';
+
+export default Ember.Component.extend({
+  @computed('first', 'last')
+  name: {
+    get(first, last) {
+      return `${first} ${last}`;
+    },
+
+    set(value, first, last) {
+      // ...
+    }
+});
+```
+
 ## Installation
 
 * `git clone` this repository

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
     "ember-data": "1.0.0-beta.16.1",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-export-application-global": "^1.0.2",
-    "ember-new-computed": "1.0.0",
     "ember-try": "0.0.4"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.0.0",
+    "ember-new-computed": "1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "ember-cli-qunit": "0.3.10",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
-    "ember-export-application-global": "^1.0.2",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-export-application-global": "^1.0.2",
+    "ember-new-computed": "1.0.0",
     "ember-try": "0.0.4"
   },
   "keywords": [

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -67,7 +67,7 @@ test('only calls getter when dependent keys change', function(assert) {
 });
 
 test('throws an error when attempting to use ES6 getter/setter syntax', function(assert) {
-  assert.throws(function() {
+  assert.throws(() => {
     let obj = {
       first: 'rob',
       last: 'jackson',
@@ -82,7 +82,7 @@ test('throws an error when attempting to use ES6 getter/setter syntax', function
   });
 });
 
-skip('allows using ember-new-computed style get/set syntax', function(assert) {
+test('allows using ember-new-computed style get/set syntax', function(assert) {
   // not currently supported by Babel (waiting on confirmation from @wycats
   // before opening an issue)
   let setCallCount = 0;
@@ -95,14 +95,14 @@ skip('allows using ember-new-computed style get/set syntax', function(assert) {
     @computed('first', 'last')
     /* jshint ignore:end */
     name: {
-      get: function(first, last) {
+      get(first, last) {
         assert.equal(first, 'rob');
         assert.equal(last, 'jackson');
 
         getCallCount++;
       },
 
-      set: function(value, first, last) {
+      set(value, first, last) {
         assert.equal(first, 'rob');
         assert.equal(last, 'jackson');
 


### PR DESCRIPTION
- introduces `"ember-new-computed": "1.0.0",` so we can use this syntax today.
- then makes it actually work