### PR TITLE
add other computed macros

### DIFF
--- a/addon/decorator-alias.js
+++ b/addon/decorator-alias.js
@@ -1,0 +1,19 @@
+export default function decoratorAlias(fn, errorMessage) {
+  return function(...params) {
+    // determine if user called as @computed('blah', 'blah') or @computed
+    if (params.length === 0) {
+      throw new Error(errorMessage);
+    } else {
+      return function(target, key, desc) {
+        return {
+          enumerable: desc.enumerable,
+          configurable: desc.configurable,
+          writalbe: desc.writable,
+          initializer: function() {
+            return fn.apply(null, params.concat(desc.initializer()));
+          }
+        };
+      };
+    }
+  };
+}

--- a/addon/ember-data.js
+++ b/addon/ember-data.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+import macroAlias from './macro-alias';
+
+export var attr = macroAlias(DS.attr);
+export var hasMany = macroAlias(DS.hasMany);
+export var belongsTo = macroAlias(DS.belongsTo);

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,57 +1,7 @@
 import Ember from 'ember';
 
-const { get } = Ember;
-
-import computed from 'ember-new-computed';
-
-function handleDescriptor(target, key, desc, params = []) {
-  return {
-    enumerable: desc.enumerable,
-    configurable: desc.configurable,
-    writeable: desc.writeable,
-    initializer: function() {
-      let computedDescriptor;
-
-      if (desc.writable) {
-        var val = desc.initializer();
-        if (typeof val === 'object') {
-          let value = { };
-          if (val.get) { value.get = callUserSuppliedGet(params, val.get); }
-          if (val.set) { value.set = callUserSuppliedSet(params, val.set); }
-          computedDescriptor = value;
-        } else {
-          computedDescriptor = callUserSuppliedGet(params, val);
-        }
-      } else {
-        throw new Error('ember-computed-decorators does not support using getters and setters');
-      }
-
-      return computed.apply(null, params.concat(computedDescriptor));
-    }
-  };
-}
-
-function callUserSuppliedGet(params, func) {
-  return function() {
-    let paramValues = params.map(p => get(this, p));
-
-    return func.apply(this, paramValues);
-  };
-}
-
-
-function callUserSuppliedSet(params, func) {
-  return function(value) {
-    let paramValues = params.map(p => get(this, p));
-    paramValues.unshift(value);
-
-    return func.apply(this, paramValues);
-  };
-}
-
-function isDescriptor(item) {
-  return item && typeof item === 'object';
-}
+import handleDescriptor from './utils/handle-descriptor';
+import isDescriptor from './utils/is-descriptor';
 
 export default function computedDecorator(...params) {
   // determine if user called as @computed('blah', 'blah') or @computed
@@ -75,43 +25,12 @@ export function readOnly(target, name, desc) {
   };
 }
 
-function decoratorAlias(fn, errorMessage) {
-  return function(...params) {
-    // determine if user called as @computed('blah', 'blah') or @computed
-    if (params.length === 0) {
-      throw new Error(errorMessage);
-    } else {
-      return function(target, key, desc) {
-        return {
-          enumerable: desc.enumerable,
-          configurable: desc.configurable,
-          writalbe: desc.writable,
-          initializer: function() {
-            return fn.apply(null, params.concat(desc.initializer()));
-          }
-        };
-      };
-    }
-  };
-}
+import decoratorAlias from './decorator-alias';
 
 export var on = decoratorAlias(Ember.on, 'Can not `on` without event names');
 export var observes = decoratorAlias(Ember.observer, 'Can not `observe` without property names');
 
-function macroAlias(fn) {
-  return function(...params) {
-    return function(target, propertyName, desc) {
-      return {
-        enumerable: desc.enumerable,
-        configurable: desc.configurable,
-        writable: desc.writable,
-        initializer: function() {
-          return fn(...params);
-        }
-      };
-    };
-  };
-}
+import macroAlias from './macro-alias';
 
 export var alias = macroAlias(Ember.computed.alias);
 export var empty = macroAlias(Ember.computed.empty);

--- a/addon/index.js
+++ b/addon/index.js
@@ -4,26 +4,31 @@ const { get } = Ember;
 
 import computed from 'ember-new-computed';
 
-function handleDescriptor(target, key, descriptor) {
-  let originalParams = descriptor.__originalParams || [];
-  let computedDescriptor;
+function handleDescriptor(target, key, desc, params = []) {
+  return {
+    enumerable: desc.enumerable,
+    configurable: desc.configurable,
+    writeable: desc.writeable,
+    initializer: function() {
+      let computedDescriptor;
 
-  if (descriptor.writable) {
-    if (typeof descriptor.value === 'object') {
-      let value = { };
-      if (descriptor.value.get) { value.get = callUserSuppliedGet(originalParams, descriptor.value.get); }
-      if (descriptor.value.set) { value.set = callUserSuppliedSet(originalParams, descriptor.value.set); }
-      computedDescriptor = value;
-    } else {
-      computedDescriptor = callUserSuppliedGet(originalParams, descriptor.value);
+      if (desc.writable) {
+        var val = desc.initializer();
+        if (typeof val === 'object') {
+          let value = { };
+          if (val.get) { value.get = callUserSuppliedGet(params, val.get); }
+          if (val.set) { value.set = callUserSuppliedSet(params, val.set); }
+          computedDescriptor = value;
+        } else {
+          computedDescriptor = callUserSuppliedGet(params, val);
+        }
+      } else {
+        throw new Error('ember-computed-decorators does not support using getters and setters');
+      }
+
+      return computed.apply(null, params.concat(computedDescriptor));
     }
-  } else {
-    throw new Error('ember-computed-decorators does not support using getters and setters');
-  }
-
-  descriptor.value = computed.apply(null, originalParams.concat(computedDescriptor));
-
-  return descriptor;
+  };
 }
 
 function callUserSuppliedGet(params, func) {
@@ -53,23 +58,21 @@ export default function computedDecorator(...params) {
   if (isDescriptor(params[params.length - 1])) {
     return handleDescriptor(...arguments);
   } else {
-    return function(target, key, descriptor) {
-      descriptor.__originalParams = params;
-
-      return handleDescriptor(...arguments);
+    return function(/* target, key, desc */) {
+      return handleDescriptor(...arguments, params);
     };
   }
 }
 
-export function readOnly(target, name, descriptor) {
-  descriptor.writable = false;
-  var value = typeof descriptor === 'object' && descriptor && descriptor.value;
-
-  if (value && typeof value === 'object' && value.isDescriptor) {
-    value.readOnly();
-  }
-
-  return descriptor;
+export function readOnly(target, name, desc) {
+  return {
+    writable:     false,
+    enumerable:   desc.enumerable,
+    configurable: desc.configurable,
+    initializer:  function() {
+      return desc.initializer().readOnly();
+    }
+  };
 }
 
 function decoratorAlias(fn, errorMessage) {
@@ -78,9 +81,15 @@ function decoratorAlias(fn, errorMessage) {
     if (params.length === 0) {
       throw new Error(errorMessage);
     } else {
-      return function(target, key, descriptor) {
-        descriptor.value = fn.apply(null, params.concat(descriptor.value));
-        return descriptor;
+      return function(target, key, desc) {
+        return {
+          enumerable: desc.enumerable,
+          configurable: desc.configurable,
+          writalbe: desc.writable,
+          initializer: function() {
+            return fn.apply(null, params.concat(desc.initializer()));
+          }
+        };
       };
     }
   };
@@ -88,3 +97,36 @@ function decoratorAlias(fn, errorMessage) {
 
 export var on = decoratorAlias(Ember.on, 'Can not `on` without event names');
 export var observes = decoratorAlias(Ember.observer, 'Can not `observe` without property names');
+
+function macroAlias(fn) {
+  return function(...params) {
+    return function(target, propertyName, desc) {
+      return {
+        enumerable: desc.enumerable,
+        configurable: desc.configurable,
+        writable: desc.writable,
+        initializer: function() {
+          return fn(...params);
+        }
+      };
+    };
+  };
+}
+
+export var alias = macroAlias(Ember.computed.alias);
+export var empty = macroAlias(Ember.computed.empty);
+export var notEmpty = macroAlias(Ember.computed.notEmpty);
+export var none = macroAlias(Ember.computed.none);
+export var not = macroAlias(Ember.computed.not);
+export var bool = macroAlias(Ember.computed.bool);
+export var match = macroAlias(Ember.computed.match);
+export var equal = macroAlias(Ember.computed.equal);
+export var gt = macroAlias(Ember.computed.gt);
+export var gte = macroAlias(Ember.computed.gte);
+export var lt = macroAlias(Ember.computed.lt);
+export var lte = macroAlias(Ember.computed.lte);
+export var and = macroAlias(Ember.computed.and);
+export var or = macroAlias(Ember.computed.or);
+export var any = macroAlias(Ember.computed.any);
+export var collect = macroAlias(Ember.computed.collect);
+export var oneWay = macroAlias(Ember.computed.oneWay);

--- a/addon/macro-alias.js
+++ b/addon/macro-alias.js
@@ -1,0 +1,24 @@
+import isDescriptor from './utils/is-descriptor';
+
+function handleDescriptor(target, property, desc, fn, params = []) {
+  return {
+    enumerable: desc.enumerable,
+    configurable: desc.configurable,
+    writable: desc.writable,
+    initializer: function() {
+      return fn(...params);
+    }
+  };
+}
+
+export default function macroAlias(fn) {
+  return function(...params) {
+    if (isDescriptor(params[params.length - 1])) {
+      return handleDescriptor(...params, fn);
+    } else {
+      return function(target, property, desc) {
+        return handleDescriptor(target, property, desc, fn, params);
+      };
+    }
+  };
+}

--- a/addon/utils/handle-descriptor.js
+++ b/addon/utils/handle-descriptor.js
@@ -1,0 +1,50 @@
+import Ember from 'ember';
+import computed from 'ember-new-computed';
+
+const { get } = Ember;
+
+export default function handleDescriptor(target, key, desc, params = []) {
+  return {
+    enumerable: desc.enumerable,
+    configurable: desc.configurable,
+    writeable: desc.writeable,
+    initializer: function() {
+      let computedDescriptor;
+
+      if (desc.writable) {
+        var val = desc.initializer();
+        if (typeof val === 'object') {
+          let value = { };
+          if (val.get) { value.get = callUserSuppliedGet(params, val.get); }
+          if (val.set) { value.set = callUserSuppliedSet(params, val.set); }
+          computedDescriptor = value;
+        } else {
+          computedDescriptor = callUserSuppliedGet(params, val);
+        }
+      } else {
+        throw new Error('ember-computed-decorators does not support using getters and setters');
+      }
+
+      return computed.apply(null, params.concat(computedDescriptor));
+    }
+  };
+}
+
+function callUserSuppliedGet(params, func) {
+  return function() {
+    let paramValues = params.map(p => get(this, p));
+
+    return func.apply(this, paramValues);
+  };
+}
+
+
+function callUserSuppliedSet(params, func) {
+  return function(key, value) {
+    let paramValues = params.map(p => get(this, p));
+    paramValues.unshift(value);
+
+    return func.apply(this, paramValues);
+  };
+}
+

--- a/addon/utils/is-descriptor.js
+++ b/addon/utils/is-descriptor.js
@@ -1,0 +1,7 @@
+export default function isDescriptor(item) {
+  return item &&
+    typeof item === 'object' &&
+    'writable' in item &&
+    'enumerable' in item &&
+    'configurable' in item;
+}

--- a/tests/unit/ds-macro-test.js
+++ b/tests/unit/ds-macro-test.js
@@ -1,0 +1,43 @@
+import Ember from "ember";
+import {
+  attr,
+  hasMany,
+  belongsTo
+} from "ember-computed-decorators/ember-data";
+
+import { module, test, skip } from "qunit";
+
+const { get, set } = Ember;
+
+module('ember-data macro decorator');
+
+test('DS macro', function(assert) {
+  var Model = DS.Model.extend({
+    /* jshint ignore:start */
+    @attr firstName,
+    @attr({ defaultTo: 'blue' }) lastName,
+    @hasMany user,
+    @belongsTo car
+    /* jshint ignore:end*/
+  });
+
+  Model.store = {
+    modelFor(typeKey) {
+      return typeKey;
+    }
+  };
+
+  var attributes = [];
+  Model.eachAttribute(function(attr) {
+    attributes.push(attr);
+  });
+
+  assert.deepEqual(attributes, ['firstName', 'lastName']);
+
+  var relationships = [];
+  Model.eachRelationship(function(attr) {
+    relationships.push(attr);
+  });
+
+  assert.deepEqual(relationships, ['user', 'car']);
+});

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -1,0 +1,61 @@
+
+import Ember from "ember";
+import {
+  alias,
+  empty,
+  notEmpty,
+  none,
+  not,
+  bool,
+  match,
+  equal
+} from "ember-computed-decorators";
+import { module, test, skip } from "qunit";
+
+const { get, set } = Ember;
+
+module('macro decorator');
+
+test('alias', function(assert) {
+  var didInit = false;
+
+  var obj = Ember.Object.extend({
+    init() {
+      this._super(...arguments);
+      this.first = 'rob';
+      this.last = 'jackson';
+    },
+
+    /* jshint ignore:start */
+    @alias('first') firstName,
+    @empty('first') hasNoFirstName,
+    @notEmpty('first') hasFirstName,
+    @none('first') hasNoneFirstName,
+    @not('first') notFirstName,
+    @bool('first') boolFirstName,
+    @match('first', /rob/) firstNameMatch,
+    @equal('first', 'rob') firstNameEqual,
+    // @gt()
+    // @gte
+    // @lt
+    // @lte
+    // @and
+    // @or
+    // @any
+    // @oneWay
+    /* jshint ignore:end */
+    name() {
+      didInit = true;
+    }
+  }).create();
+
+  assert.equal(obj.get('firstName'), 'rob');
+  assert.equal(obj.get('hasNoFirstName'), false);
+  assert.equal(obj.get('hasFirstName'), true);
+  assert.equal(obj.get('hasNoneFirstName'), false);
+  assert.equal(obj.get('notFirstName'), false);
+  assert.equal(obj.get('boolFirstName'), true);
+  assert.equal(obj.get('firstNameMatch'), true);
+  assert.equal(obj.get('firstNameEqual'), true);
+
+});


### PR DESCRIPTION
(this may actually work, pending spec people telling me if i am wrong or babel is wrong)

- [X] need to report babel issue (and get the spec to add further clarification)
- [x] pending babel fix https://github.com/babel/babel/issues/1277
- [x] once the babel fix lands, we will need to update this project to take into account descriptor initializers

```js
export default Ember.Object.extend({
  init() {
    this._super(...arguments);
    this.first = 'Rob';
    this.last = 'Jackson';
  },

  @alias('first') firstName,
  @empty('first') missingFirstName,
  @match('first', /rob/i) isRob
});
```

- [x] ember-data

```js
export default DS.Model.extend({
  @attr firstName,
  @attr({ defaultTo: 'smith' }) lastName,
  @hasMany cars,
  @belongsTo human
});
```
