### PR TITLE
Normalize imports from `computedDecorator` to `computed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ foo: Ember.computed('someKey', 'otherKey', function() {
 You replace with this:
 
 ```javascript
-import computedDecorator from 'ember-computed-decorators';
+import computed from 'ember-computed-decorators';
 
 // ..... <snip> .....
-@computedDecorator('someKey', 'otherKey')
+@computed('someKey', 'otherKey')
 foo(someKey, otherKey) {
   // Do Stuff
 }
@@ -65,10 +65,10 @@ foo: Ember.computed(function() {
 You replace with this:
 
 ```javascript
-import computedDecorator from 'ember-computed-decorators';
+import computed from 'ember-computed-decorators';
 
 // ..... <snip> .....
-@computedDecorator
+@computed
 foo() {
   // Do Stuff
 }


### PR DESCRIPTION
Hi,

I was reading the README and it kind of confused me that you name it `computedDecorators` in the first few examples and then switch to `computed` in the "Real world" ones.
I know it's something small, but at least for me it helps with clarity. I thought instead of opening an issue I'd open a PR instead and that way the work is already done.

:moneybag: :moneybag: 