### PR TITLE
Pass in the part before @each/[] as attr for a CP

### DIFF
--- a/addon/utils/handle-descriptor.js
+++ b/addon/utils/handle-descriptor.js
@@ -35,7 +35,11 @@ function getAttr(obj, name) {
   let i;
 
   for (i = 0; i < parts.length; i++) {
-    if (parts[i] === '@each' || parts[i] === '[]') { break; }
+    if (parts[i] === '@each' ||
+        parts[i] === '[]'    ||
+        parts[i].indexOf('{') !== -1) {
+      break;
+    }
   }
 
   return get(obj, parts.slice(0, i).join('.'));

--- a/addon/utils/handle-descriptor.js
+++ b/addon/utils/handle-descriptor.js
@@ -30,9 +30,20 @@ export default function handleDescriptor(target, key, desc, params = []) {
   };
 }
 
+function getAttr(obj, name) {
+  const parts = name.split('.');
+  let i;
+
+  for (i = 0; i < parts.length; i++) {
+    if (parts[i] === '@each' || parts[i] === '[]') { break; }
+  }
+
+  return get(obj, parts.slice(0, i).join('.'));
+}
+
 function callUserSuppliedGet(params, func) {
   return function() {
-    let paramValues = params.map(p => get(this, p));
+    let paramValues = params.map(p => getAttr(this, p));
 
     return func.apply(this, paramValues);
   };
@@ -41,7 +52,7 @@ function callUserSuppliedGet(params, func) {
 
 function callUserSuppliedSet(params, func) {
   return function(key, value) {
-    let paramValues = params.map(p => get(this, p));
+    let paramValues = params.map(p => getAttr(this, p));
     paramValues.unshift(value);
 
     return func.apply(this, paramValues);

--- a/addon/utils/handle-descriptor.js
+++ b/addon/utils/handle-descriptor.js
@@ -30,8 +30,8 @@ export default function handleDescriptor(target, key, desc, params = []) {
   };
 }
 
-function getAttr(obj, name) {
-  const parts = name.split('.');
+function niceAttr(attr) {
+  const parts = attr.split('.');
   let i;
 
   for (i = 0; i < parts.length; i++) {
@@ -42,12 +42,13 @@ function getAttr(obj, name) {
     }
   }
 
-  return get(obj, parts.slice(0, i).join('.'));
+  return parts.slice(0, i).join('.');
 }
 
 function callUserSuppliedGet(params, func) {
+  params = params.map(niceAttr);
   return function() {
-    let paramValues = params.map(p => getAttr(this, p));
+    let paramValues = params.map(p => get(this, p));
 
     return func.apply(this, paramValues);
   };
@@ -55,8 +56,9 @@ function callUserSuppliedGet(params, func) {
 
 
 function callUserSuppliedSet(params, func) {
+  params = params.map(niceAttr);
   return function(key, value) {
-    let paramValues = params.map(p => getAttr(this, p));
+    let paramValues = params.map(p => get(this, p));
     paramValues.unshift(value);
 
     return func.apply(this, paramValues);

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -161,3 +161,53 @@ test('works properly', function(assert) {
 
   assert.equal(callCount, 1);
 });
+
+test('attr.models.@each passes attr.models', function(assert) {
+  assert.expect(2);
+
+  let obj = {
+    attr: {
+      models: ['one', 'two']
+    },
+
+    /* jshint ignore:start */
+    @computed('attr.models.@each')
+    /* jshint ignore:end */
+    something: {
+      get(models) {
+        assert.deepEqual(models, ['one', 'two']);
+      },
+      set(value, models) {
+        assert.deepEqual(models, ['one', 'two']);
+      }
+    },
+  };
+
+  get(obj, 'something');
+  set(obj, 'something', 'something');
+});
+
+test('attr.models.[] passes attr.models', function(assert) {
+  assert.expect(2);
+
+  let obj = {
+    attr: {
+      models: ['one', 'two']
+    },
+
+    /* jshint ignore:start */
+    @computed('attr.models.[]')
+    /* jshint ignore:end */
+    something: {
+      get(models) {
+        assert.deepEqual(models, ['one', 'two']);
+      },
+      set(value, models) {
+        assert.deepEqual(models, ['one', 'two']);
+      }
+    },
+  };
+
+  get(obj, 'something');
+  set(obj, 'something', 'something');
+});

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -211,3 +211,29 @@ test('attr.models.[] passes attr.models', function(assert) {
   get(obj, 'something');
   set(obj, 'something', 'something');
 });
+
+test('attr.{foo,bar} passes attr', function(assert) {
+  assert.expect(2);
+
+  let obj = {
+    attr: {
+      foo: 'foo',
+      bar: 'bar'
+    },
+
+    /* jshint ignore:start */
+    @computed('attr.{foo,bar}')
+    /* jshint ignore:end */
+    something: {
+      get(obj) {
+        assert.deepEqual(obj, { foo: 'foo', bar: 'bar' });
+      },
+      set(value, obj) {
+        assert.deepEqual(obj, { foo: 'foo', bar: 'bar' });
+      }
+    },
+  };
+
+  get(obj, 'something');
+  set(obj, 'something', 'something');
+});


### PR DESCRIPTION
Solves #20.

I also have a commit ready for `foo.{bar,baz}`, that it will pass in `foo`, but I was unsure if that is the right thing to do. The alternative is to pass in `bar` and `baz`.