### PR TITLE
chore: fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ export default Ember.Component.extend({
   address: {
     street: 'Pennsylvania Avenue',
     number: 1600
-  ],
+  },
 
   @computed('address.{street,number}')
   formattedStreet(street, number) {


### PR DESCRIPTION
Stumbled upon this today while reading over the property expansion docs.
