### PR TITLE
Fix readOnly docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,9 +529,9 @@ Where `computed.oneWay` provides oneWay bindings, `computed.readOnly` provides a
 This prevents the reverse flow, and also throws an exception when it occurs.
 ```javascript
 import Ember from 'ember';
-import { readOnly } from 'ember-computed-decorators';
+import { readOnly, alias } from 'ember-computed-decorators';
 export default Ember.Component.extend({
-  @readOnly('first') firstName // throws an error if set 'firstName' is attempted
+  @readOnly @alias('first') firstName // throws an error if set 'firstName' is attempted
 });
 ```
 


### PR DESCRIPTION
`readOnly` does not work as explained here in the docs because it doesn't correctly pass parameters into the custom `readOnly` implementation. See the screenshot:
![1 _zsh_tmux_plugin_run attach -t aha tmux 2016-05-02 15-52-45](https://cloud.githubusercontent.com/assets/781752/14965995/64910df4-107e-11e6-9046-3fbafa8ab112.jpg)

I came to realize that the `readOnly` here is not actually `Ember.computed.readOnly` but a custom implementation (seen here: [/addon/index.js#L18-L28](https://github.com/rwjblue/ember-computed-decorators/blob/0a3e6dd745715ec575ec61ecf1ce995a310261f9/addon/index.js#L18-L28)) which supports the usage described here: [/README.md#readonly](https://github.com/rwjblue/ember-computed-decorators/blob/master/README.md#readonly). In fact, it appears that this library's `readOnly` actually used to be the same as `Ember.computed.readOnly` but that functionality was removed here: https://github.com/rwjblue/ember-computed-decorators/pull/54. Furthermore, [the test](https://github.com/rwjblue/ember-computed-decorators/blob/0a3e6dd745715ec575ec61ecf1ce995a310261f9/tests/unit/macro-test.js#L492-L493) seems to test the syntax I have proposed in this PR.

Another option would be to make the function work for both syntaxes but fixing the docs to be consistent with the current implementation was the quickest fix for me.