### PR TITLE
Updating documentation for addons to not throw deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ This should enable the decorators to work on the parent app/addon.
 
 ```javascript
   init: function(app) {
+    this._super.apply(this, arguments);
+
     this.options = this.options || {};
     this.options.babel = this.options.babel || {};
     this.options.babel.optional = this.options.babel.optional || [];


### PR DESCRIPTION
Not calling `this._super` in the `init` hook for addons throws deprecations in consuming applications. Made a simple update to the addon snippet for babel decorator support in the readme.