### PR TITLE
RFC: use computed from ember-macro-helpers

### DIFF
--- a/addon/utils/handle-descriptor.js
+++ b/addon/utils/handle-descriptor.js
@@ -1,8 +1,5 @@
-import Ember from 'ember';
-import expandPropertyList from 'ember-macro-helpers/expand-property-list';
 import extractValue from './extract-value';
-
-const { computed, get } = Ember;
+import computed from 'ember-macro-helpers/computed';
 
 export default function handleDescriptor(target, key, desc, params = []) {
   return {
@@ -10,42 +7,12 @@ export default function handleDescriptor(target, key, desc, params = []) {
     configurable: desc.configurable,
     writeable: desc.writeable,
     initializer: function() {
-      let computedDescriptor;
-
-      if (desc.writable) {
-        var val = extractValue(desc);
-        if (typeof val === 'object') {
-          let value = { };
-          if (val.get) { value.get = callUserSuppliedGet(params, val.get); }
-          if (val.set) { value.set = callUserSuppliedSet(params, val.set); }
-          computedDescriptor = value;
-        } else {
-          computedDescriptor = callUserSuppliedGet(params, val);
-        }
-      } else {
+      if (!desc.writable) {
         throw new Error('ember-computed-decorators does not support using getters and setters');
       }
 
-      return computed.apply(null, params.concat(computedDescriptor));
+      let value = extractValue(desc);
+      return computed(...params.concat(value));
     }
-  };
-}
-
-function callUserSuppliedGet(params, func) {
-  const expandedParams = expandPropertyList(params);
-  return function() {
-    let paramValues = expandedParams.map(p => get(this, p));
-
-    return func.apply(this, paramValues);
-  };
-}
-
-function callUserSuppliedSet(params, func) {
-  const expandedParams = expandPropertyList(params);
-  return function(key, value) {
-    let paramValues = expandedParams.map(p => get(this, p));
-    paramValues.unshift(value);
-
-    return func.apply(this, paramValues);
   };
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-macro-helpers": "0.3.0"
+    "ember-macro-helpers": "0.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
The property expansion and resolved value passing exists in [ember-macro-helpers](https://github.com/kellyselden/ember-macro-helpers) if you want it. You can eliminate some code on your end. There may be a little overhead though because the `computed` from ember-macro-helpers also supports composing.