### PR TITLE
[BUGFIX] Missing curly brackets in objects computed documentation

### DIFF
--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -79,7 +79,7 @@ export const action = decorator(function(target, key, desc) {
  *
  * ```javascript
  * import Component from '@ember/component';
- * import computed from 'ember-decorators/object';
+ * import { computed } from 'ember-decorators/object';
  *
  * export default class UserProfileComponent extends Component {
  *   first = 'John';


### PR DESCRIPTION
The import statement in the example of `computed` where missing the curly brackets. Copy paste of the code results in an error.