### PR TITLE
drop support for Ember < 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,6 @@ jobs:
       env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
-    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.4
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8
     - env: EMBER_TRY_SCENARIO=ember-lts-3.12
     - env: EMBER_TRY_SCENARIO=typescript

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -13,30 +13,6 @@ module.exports = function() {
       scenarios: [
         // Ember Versions
         {
-          name: 'ember-lts-2.16',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.16.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-2.18',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.18.0',
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.4',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.4.0',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.8',
           npm: {
             devDependencies: {


### PR DESCRIPTION
This is being done in preparation for #494 so we can make the changelog a bit more user friendly

CI is not currently running on this repo so this PR is purely to have it visible in the changelog