### PR TITLE
Docs: `ember-decorators` no longer transitively provides @ember-decorators/ packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,18 @@ documentation for all the decorators included in this addon.
 Usage
 ------------------------------------------------------------------------------
 
-First install the main `ember-decorators` addon.
-
-```sh
-ember install ember-decorators
-```
-
-This addon doesn't contain any decorators itself, but includes the core set of
-subaddons that are necessary to begin writing Ember using native classes:
-
+The addon is split into `object` and `component` decorators:
 * `@ember-decorators/component`
 * `@ember-decorators/object`
+
+You can run the following command to install both packages:
+
+```sh
+npm install @ember-decorators/component @ember-decorators/object -D
+```
+
+> [!NOTE]
+> If you're coming from v6 and earlier, the meta package `ember-decorators` no longer transitively ships the individual packages for your apps. You must install them directly.
 
 See the [API Documentation](https://ember-decorators.github.io/ember-decorators)
 for detailed examples and documentation of the individual decorators.

--- a/packages/-ember-decorators/README.md
+++ b/packages/-ember-decorators/README.md
@@ -18,9 +18,18 @@ detailed API documentation for all the decorators included in this library.
 Installation
 ------------------------------------------------------------------------------
 
+The addon is split into `object` and `component` decorators:
+* `@ember-decorators/component`
+* `@ember-decorators/object`
+
+You can run the following command to install both packages:
+
+```sh
+npm install @ember-decorators/component @ember-decorators/object -D
 ```
-ember install ember-decorators
-```
+
+> [!NOTE]
+> If you're coming from v6 and earlier, the meta package `ember-decorators` no longer transitively ships the individual packages for your apps. You must install them directly.
 
 License
 ------------------------------------------------------------------------------

--- a/packages/docs/tests/dummy/app/pods/docs/cheat-sheet/template.md
+++ b/packages/docs/tests/dummy/app/pods/docs/cheat-sheet/template.md
@@ -5,7 +5,18 @@ native classes with Ember.
 
 ## Installation
 
-* `ember install ember-decorators`
+The addon is split into `object` and `component` decorators:
+* `@ember-decorators/component`
+* `@ember-decorators/object`
+
+You can run the following command to install both packages:
+
+```sh
+npm install @ember-decorators/component @ember-decorators/object -D
+```
+
+<aside>If you're coming from v6 and earlier, the meta package `ember-decorators` no longer transitively ships the individual packages for your apps. You must install them directly.</aside>
+
 * Troubleshooting
   * Make sure the latest `ember-cli-babel` is installed
   * Make sure `babel-eslint` was installed and set to be the parser in

--- a/packages/docs/tests/dummy/app/pods/docs/index/template.md
+++ b/packages/docs/tests/dummy/app/pods/docs/index/template.md
@@ -2,30 +2,17 @@
 
 ## Installation
 
-First, install the package:
+The addon is split into `object` and `component` decorators:
+* `@ember-decorators/component`
+* `@ember-decorators/object`
+
+You can run the following command to install both packages:
 
 ```sh
-ember install ember-decorators
+npm install @ember-decorators/component @ember-decorators/object -D
 ```
 
-This will add the package, and should also add several babel packages to your
-app. You should see the following added to you `package.json`:
-
-```json
-"ember-decorators": "{{latest version}}",
-"babel-eslint": "{{latest version}}",
-```
-
-And in your `.eslintrc.js`, you should see the following line added:
-
-```
-  parser: 'babel-eslint',
-```
-
-These packages and settings are necessary for babel and eslint to understand
-decorators and class fields and correctly transpile/lint them. You should also
-ensure that you are using at least `ember-cli-babel@v7.7.3`, since it adds
-support for class fields and decorators.
+<aside>If you're coming from v6 and earlier, the meta package `ember-decorators` no longer transitively ships the individual packages for your apps. You must install them directly.</aside>
 
 ## Usage
 
@@ -36,8 +23,6 @@ including:
 
 - `@ember-decorators/component`
 - `@ember-decorators/object`
-
-Now you can write Ember using native classes! For example, this:
 
 ```javascript
 import Component from '@ember/component';


### PR DESCRIPTION
Documents the fact that `@ember-decorators/` packages must be installed directly as transitive/extraneous dependencies are not allowed.